### PR TITLE
Add MSCC RNG algorithm + some miscellaneous cleanup

### DIFF
--- a/Search.c
+++ b/Search.c
@@ -80,6 +80,10 @@ int main(int argc, const char* argv[]) {
     fclose(file);
 
     file = fopen(argv[1], "rb"); //The route filename should be provided via command line
+    if (file == NULL) {
+        perror(argv[1]);
+        return 1;
+    }
     char character;
     while ((character = fgetc(file)) != EOF) { //Sharpeye's code for getting a file size that doesn't rely on SEEK_END
         routeLength++; //EOF is not a part of the original file and therefore incrementing the variable even after hitting means that the variable is equal to the file size

--- a/Search.c
+++ b/Search.c
@@ -21,6 +21,11 @@ enum {
     WEST = 3
 };
 
+enum {
+    ODD = 0,
+    EVEN =1
+};
+
 /*
  * How each move is represented via the index position system
  */
@@ -90,8 +95,8 @@ int main(int argc, const char* argv[]) {
         char tile = mapInitial[c];
         switch (tile) {
             case(BLOB_N): ;
-                BLOB b = {c, NORTH}; //All the blobs are facing up
                 if (listIndex < NUM_BLOBS) {
+                    BLOB b = {c, NORTH}; //All the blobs are facing up
                     monsterListInitial[listIndex] = b;
                     listIndex++;
                 }
@@ -163,17 +168,19 @@ int main(int argc, const char* argv[]) {
         pthread_join(threadIDs[t], NULL);
     }
 
+    //unsigned long numSeeds = lastSeed - firstSeed + 1;
     //clock_t time_b = clock();
+    //double duration = time_b - time_a;
 
-    //printf("searched %ld seeds in %f ms\n", lastSeed-firstSeed+1, (time_b-time_a) * (1e3 / CLOCKS_PER_SEC));
-    //printf("average %.1f us/seed\n", (time_b-time_a) * (1e6 / CLOCKS_PER_SEC) / (lastSeed-firstSeed+1));
+    //printf("searched %lu seeds in %f ms\n", numSeeds, duration * (1e3 / CLOCKS_PER_SEC));
+    //printf("average %.1f us/seed\n", duration * (1e6 / CLOCKS_PER_SEC) / numSeeds);
 }
 
 static void* searchPools(void* args) {
     POOLINFO *poolInfo = ((POOLINFO*) args);
     for (unsigned long seed = poolInfo->poolStart; seed <= poolInfo->poolEnd; seed++) {
-        searchSeed(seed, 1); //EVEN then ODD
-        searchSeed(seed, 0);
+        searchSeed(seed, EVEN);
+        searchSeed(seed, ODD);
     }
     return NULL;
 }
@@ -219,7 +226,9 @@ static void searchSeed(unsigned long seed, int step) { //Step: 1 = EVEN, 0 = ODD
     memcpy(map, mapInitial, 1024);
     memcpy(monsterList, monsterListInitial, sizeof(struct BLOB)*NUM_BLOBS); //Set up copies of the arrays to be used so we don't have to read from file each time
 
-    if (step) moveChip(route[0], &chipIndex, map);
+    if (step == EVEN) {
+        moveChip(route[0], &chipIndex, map);
+    }
     int i=step;
     while (i < routeLength) {
         moveChip(route[i++], &chipIndex, map);
@@ -233,7 +242,7 @@ static void searchSeed(unsigned long seed, int step) { //Step: 1 = EVEN, 0 = ODD
         moveChip(route[i++], &chipIndex, map);
         if (map[chipIndex] == BLOB_N) return;
     }
-    printf("Successful seed: %lu, Step: %c\n", startingSeed, step ? 'E' : 'O');
+    printf("Successful seed: %lu, Step: %s\n", startingSeed, step == EVEN ? "even" : "odd");
 }
 
 static void moveChip(char dir, int *chipIndex, unsigned char map[]) {

--- a/Search.c
+++ b/Search.c
@@ -197,20 +197,19 @@ static bool verifyRoute(void) {
     memcpy(monsterList, monsterListInitial, sizeof(struct BLOB)*NUM_BLOBS);
 
     int chipsNeeded = 88;
-    int ok = true;
     for (int i = 0; i < routeLength; i++) {
         int dir = route[i];
         chipIndex = chipIndex + dir;
         if (map[chipIndex] == WALL) {
             printf("hit a wall at move %d\n", i);
-            ok = false;
-            break;
+            return false;
         }
         if (map[chipIndex] == COSMIC_CHIP) {
             map[chipIndex] = FLOOR;
             chipsNeeded -= 1;
         }
     }
+    int ok = true;
     if (chipsNeeded > 0) {
         printf("route does not collect all chips\n");
         ok = false;


### PR DESCRIPTION
Add the MSCC RNG alongside the current functions.
The algorithm is described in my notes from the disassembly:
<https://tilde.town/~magical/chip/mscc-rng.txt>.

MS is about 1.5× slower than TW because the algorithm for blob movement
is more elaborate than TW and it makes more calls to the RNG function.
There's not much that we can do about that.

There are now two copies of moveBlob: moveBlobMS and moveBlobTW.
searchSeed picks the right movement function based on an "rng type" enum
passed into it. I tried passing moveBlob in as a function pointer
instead, but the overhead from making an indirect function call was too
great. Using an enum is much less costly and also allows us to print the
name of the ruleset when we find a successful seed.

Note that the order of the enum might be important - i got run times
that were 0.2 µs/seed slower the other way around. I'm not sure why;
perhaps it's affecting code layout? It could be measurement noise but it
seems pretty consistent. In any case, the difference is tiny.

Testing
-----

A Sickly Silver Moon used a memory editor to capture the state
of MSCC's RNG at the start of the level and after the blobs' first move.
I verified that starting the search program from the same seed results
in the same RNG state after the blobs move.

Here are the RNG values we tested:

| Initial    | After all blobs move once |
| ---------- | ------------------------- |
| 0xC6878D78 | 0xD0B9F3C6                |
| 0xB5FAC798 | 0xE9381162                |

We also dumped the map and checked that the positions of the blobs
match.

